### PR TITLE
Use atomic waker for task wakeup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.4.2"
 edition = "2021"
 description = "Async & reactive synchronization model to keep multiple async tasks / threads partially synchronized."
 authors = [
-    "Mara Schulke <mara.schulke@hum-systems.com>",
-    "Florian Uekermann <florian.uekermann@hum-systems.com>"
+  "Mara Schulke <mara.schulke@hum-systems.com>",
+  "Florian Uekermann <florian.uekermann@hum-systems.com>",
 ]
 repository = "https://github.com/hemisphere-studio/async-observable"
 documentation = "https://docs.rs/async-observable"
@@ -15,11 +15,12 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
+uuid = { version = "*", features = ["v4"] }
 futures = "0.3"
 slab = "0.4"
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = [ "attributes" ] }
+async-std = { version = "1.12.0", features = ["attributes"] }
 serde_json = "1"
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT"
 [dependencies]
 uuid = { version = "*", features = ["v4"] }
 futures = "0.3"
+futures-util = "0.3"
 slab = "0.4"
 serde = { version = "1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ license = "MIT"
 [dependencies]
 uuid = { version = "*", features = ["v4"] }
 futures = "0.3"
-futures-util = "0.3"
-slab = "0.4"
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,9 @@ where
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
+        println!("async-observable::stream::preguard");
         let mut guard = self.lock();
+        println!("async-observable::stream::postguard");
         let inner = guard.deref_mut();
 
         if self.version == inner.version {
@@ -439,6 +441,7 @@ where
 
             self.waker_id = Some(waker_id);
 
+            println!("async-observable::stream::pending");
             Poll::Pending
         } else {
             if let Some(waker) = self.waker_id {
@@ -452,6 +455,7 @@ where
             self.waker_id = None;
             self.version = version;
 
+            println!("async-observable::stream::ready");
             Poll::Ready(Some(value))
         }
     }
@@ -463,7 +467,9 @@ where
 {
     fn drop(&mut self) {
         if let Some(waker) = self.waker_id {
+            println!("async-observable::drop::preguard");
             let mut guard = self.lock();
+            println!("async-observable::drop::postguard");
             let inner = guard.deref_mut();
             inner.waker.try_remove(waker);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub struct Observable<T>
 where
     T: Clone,
 {
-    uuid: uuid::Uuid,
+    pub uuid: uuid::Uuid,
     inner: Arc<Mutex<Inner<T>>>,
     version: u128,
     waker_id: Option<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,15 +103,28 @@ const INITIAL_VERSION: u128 = 1;
 /// guarantees that all forked observables will receive every change!** But as long as every
 /// observable is constently asking for changes (via `next()`) you are guaranteed that every
 /// observable received the latest version.
-#[derive(Clone)]
 pub struct Observable<T>
 where
     T: Clone,
 {
-    pub uuid: uuid::Uuid,
+    uuid: uuid::Uuid,
     inner: Arc<Mutex<Inner<T>>>,
     version: u128,
     waker_id: Option<usize>,
+}
+
+impl<T> Clone for Observable<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            uuid: uuid::Uuid::new_v4(),
+            inner: self.inner.clone(),
+            version: self.version,
+            waker_id: None,
+        }
+    }
 }
 
 impl<T> Observable<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub struct Observable<T>
 where
     T: Clone,
 {
-    uuid: uuid::Uuid,
+    pub uuid: uuid::Uuid,
     inner: Arc<Mutex<Inner<T>>>,
     version: u128,
     waker_id: Option<usize>,


### PR DESCRIPTION
This MR fixes a bug related to task wakeup by using `AtomicWaker`. Also `slab` is replaced via a `HashMap<u128, AtomicWaker>` which is slightly more expensive, but easier to reason about the state of the list of wakers as each `Observable` now maintains one entry in the waker map.