### PR TITLE
Add `Observable::try_modify`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,11 @@ where
     {
         let mut inner = self.lock();
 
-        let output = change(&mut inner.value)?;
+        let mut value = inner.value.clone();
 
+        let output = change(&mut value)?;
+
+        inner.value = value;
         inner.version += 1;
 
         for (_, waker) in inner.waker.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,8 +284,14 @@ where
     where
         F: FnOnce(&mut T) -> bool,
     {
-        self.try_apply(|m| Result::<bool, ()>::Ok(change(m)))
-            .expect("Try apply with unfailible change function cant error")
+        self.try_apply(|m| {
+            if change(m) {
+                return Ok(());
+            }
+
+            Err(())
+        })
+        .is_ok()
     }
 
     /// Same as clone, but *the reset causes the fork to instantly have a change available* with the
@@ -392,6 +398,7 @@ where
         };
 
         self.version = version;
+
         value
     }
 


### PR DESCRIPTION
This pull request adds a `try_modify` function to `Observable`s which allows to run potentially failable code and abort modifications on `Err` cases.

The public signature allows to pass a function `modify` which may modify the underlying `&mut T`

```rust
pub fn try_modify<M, O, E>(&mut self, modify: M) -> Result<O, E>
where
    M: FnOnce(&mut T) -> Result<O, E>;
```

and may be used as such:

```rust
fn main() -> eyre::Result<()> {
    let (mut observable, mut listener) = Observable::new(vec![1]).split();

    let pop = |v: &mut Vec<usize>| v.pop().wrap_err("failed to pop");

    assert!(observable.try_modify(pop), "pops the first element from the underlying vector");
    assert_eq!(listener.next().await, vec![]);

    assert!(observable.try_modify(pop).is_err(), "no elements remained in the vector");
    assert_eq!(listener.latest(), vec![]);

    Ok(())
}
```